### PR TITLE
Disable multiviews to make /description work

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,3 +7,5 @@ RewriteCond %{REQUEST_FILENAME} !-d
 
 RewriteRule ^index$ / [R,L]
 RewriteRule ^(.*) public/$1  [L]
+
+Options -MultiViews


### PR DESCRIPTION
/description does not work on servers with activated option MultiViews. 

There are two possibilities to handle this:
 a) rename description.md to something else like Description.md
 b) disable mutliviews in htaccess

This patch disables Multiviews
