### PR TITLE
Changed awk to sed for compatibility

### DIFF
--- a/bin/load_csv_log.sh
+++ b/bin/load_csv_log.sh
@@ -33,7 +33,7 @@ test "$TRACE" && set -x
 
 while test "$1"; do
 
-    GUID=$(echo "$1" | sed -n 's/.*\(\([a-z0-9]\{4\}-\)\{7\}[a-z0-9]\{4\}\)\/.*\.csv/\1/p')
+    GUID=$(echo "$1" | sed -n 's/.*\(\([a-z0-9]\{4\}-\)\{7\}[a-z0-9]\{4\}\).*/\1/p')
     test "$GUID" || error_exit "No sensor GUID in filename detected"
 
     test "$TEST" || PVLngPUT2CSV $GUID "@$1"


### PR DESCRIPTION
Ubuntu/Debian don't have the same awk as openSUSE, so the GUID match didn't work for me. Because of that I changed awk to sed. 

I've tested it on openSUSE (12.2), Debian (7) and Ubuntu (12.04) and it worked fine.
