### PR TITLE
Changed awk to sed for debian/ubuntu systems

### DIFF
--- a/bin/load_csv_log.sh
+++ b/bin/load_csv_log.sh
@@ -33,7 +33,7 @@ test "$TRACE" && set -x
 
 while test "$1"; do
 
-    GUID=$(echo "$1" | awk '{ match($1, "([a-z0-9]{4}-){7}[a-z0-9]{4}", a) } END { print a[0] }')
+    GUID=$(echo "$1" | sed -n 's/.*\(\([a-z0-9]\{4\}-\)\{7\}[a-z0-9]\{4\}\).*/\1/p')
     test "$GUID" || error_exit "No sensor GUID in filename detected"
 
     test "$TEST" || PVLngPUT2CSV $GUID "@$1"


### PR DESCRIPTION
Ubuntu/Debian don't have the same awk syntax(?) as openSUSE, so I had to change from awk to sed.

I tested the sed match pattern on:
openSUSE 12.2
Debian 7
Ubuntu 12.04
